### PR TITLE
Add Trustabl Agent Scanner to CI

### DIFF
--- a/.github/workflows/trustabl.yml
+++ b/.github/workflows/trustabl.yml
@@ -1,0 +1,33 @@
+name: Trustabl Agent Scanner
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+# Minimal top-level permissions; write grants are scoped to the scan job only.
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    concurrency:
+      group: trustabl-${{ github.ref }}
+      cancel-in-progress: true
+    permissions:
+      contents: read
+      security-events: write
+      pull-requests: write
+    # continue-on-error keeps this job advisory — findings are reported but
+    # CI does not go red so unrelated work is never blocked.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: trustabl/trustabl-action@973f666d20b5fbb2e6a4511bd3846e965a08c28b # v0.4.1
+        with:
+          version: v0.1.6


### PR DESCRIPTION
We came across your repo and we like how you're building a powerful set of tools to integrate Oracle Cloud Infrastructure services with n8n workflows. We scanned the repo, and noticed agent runtime reliability findings that might be worth reviewing.

1. [LOW] LangChain project ships no agent-guidance doc (AGENTS.md/CLAUDE.md)
   What it means: The project uses LangChain / LangGraph in code but ships no agent-guidance doc (AGENTS.md/CLAUDE.md).  This makes it difficult for developers to understand how agents are configured and used in the project. 

2. [LOW] TypeScript LangChain tool has no description
   File: nodes/OCI/VectorStore/VectorStoreOracleTool.node.ts
   What it means: LangChain. The TypeScript LangChain tool within this file lacks a description, making it unclear what its purpose is and how it functions within the larger project.

Recommendations are based on our understanding of agent runtime reliability, some findings may be intentional. Please let us know if this was intentional or if our findings are helpful so we can improve the accuracy of the scanner.

Best,
Trustabl.ai
Open-source AI agent reliability scanner (runs locally, GitHub Action)